### PR TITLE
Feature/add alt text to full width img and remove uppercasing of the headings

### DIFF
--- a/src/components/contentful/contentfulContentBoxGroup/contentfulContentBoxGroup.scss
+++ b/src/components/contentful/contentfulContentBoxGroup/contentfulContentBoxGroup.scss
@@ -2,7 +2,7 @@
 
 ContentBoxGroup__title {
   width: 100%;
-  text-align: center
+  text-align: center;
 }
 
 .ContentBoxGroup__section {
@@ -37,15 +37,21 @@ ContentBoxGroup__title {
   }
 
   @include media-breakpoint-up(md) {
-    width: calc(#{map-get($container-max-widths, md)} / 2 - #{$grid-gutter-width} / 2);
+    width: calc(
+      #{map-get($container-max-widths, md)} / 2 - #{$grid-gutter-width} / 2
+    );
   }
 
   @include media-breakpoint-up(lg) {
-    width: calc(#{map-get($container-max-widths, lg)} / 2 - #{$grid-gutter-width} / 2);
+    width: calc(
+      #{map-get($container-max-widths, lg)} / 2 - #{$grid-gutter-width} / 2
+    );
   }
 
   @include media-breakpoint-up(xl) {
-    width: calc(#{map-get($container-max-widths, xl)} / 2 - #{$grid-gutter-width} / 2);
+    width: calc(
+      #{map-get($container-max-widths, xl)} / 2 - #{$grid-gutter-width} / 2
+    );
   }
 }
 
@@ -53,7 +59,7 @@ ContentBoxGroup__title {
   font-size: 1.8125rem;
   line-height: 1.2;
   margin-bottom: 1rem;
-  font-family: "Alegreya Sans";
+  font-family: 'Alegreya Sans';
   text-transform: uppercase;
 }
 
@@ -91,7 +97,6 @@ ContentBoxGroup__title {
     flex-grow: 1;
     justify-content: flex-end;
   }
-
 }
 
 .ContentBox__overlay-link-arrow {

--- a/src/components/contentful/contentfulFullWidthImage/contentfulFullWidthImage.js
+++ b/src/components/contentful/contentfulFullWidthImage/contentfulFullWidthImage.js
@@ -2,7 +2,7 @@ import React from 'react';
 import './contentfulFullWidthImage.scss';
 
 const ContentfulFullWidthImage = ({ content }) => {
-  const altText = content.imageTitle || '';
+  const altText = content.image.description || '';
   return (
     <section className="full-width-section">
       <div className="FullWidthImage layout-container">

--- a/src/components/layout.scss
+++ b/src/components/layout.scss
@@ -651,12 +651,10 @@ h6 {
 
 h1 {
   font-size: 2.8rem;
-  text-transform: uppercase;
 }
 
 h2 {
   font-size: 1.8rem;
-  text-transform: uppercase;
 }
 
 .main-container {

--- a/src/queries.js
+++ b/src/queries.js
@@ -85,6 +85,7 @@ export const ContenfulPage = graphql`
         imageTitle
         showTitle
         image {
+          description
           file {
             url
           }


### PR DESCRIPTION
This PR fixes #32 as I realised we could actually use the description for the full width images too.

Also, I removed uppercasing from the headings. This lead to some formatting happening on the files I touched, so that's why there are some semicolons added etc.