### PR TITLE
Feature/more accessibility improvements

### DIFF
--- a/src/components/contentful/contentfulContentBoxGroup/contentfulContentBoxGroup.scss
+++ b/src/components/contentful/contentfulContentBoxGroup/contentfulContentBoxGroup.scss
@@ -1,8 +1,8 @@
 @import '../../../scss/grid.scss';
 
-ContentBoxGroup__title {
+.ContentBoxGroup__title {
   width: 100%;
-  text-align: center
+  text-align: center;
 }
 
 .ContentBoxGroup__section {
@@ -35,17 +35,35 @@ ContentBoxGroup__title {
   &--is-link {
     padding-right: 2rem;
   }
+  & a:focus {
+    outline: 0.25rem solid #fec3c8;
+    outline-offset: 0.15rem;
+  }
+  &:focus-within {
+    outline: 0.25rem solid #fec3c8;
+    outline-offset: 0.25rem;
+  }
+
+  &:focus-within a:focus {
+    outline: none;
+  }
 
   @include media-breakpoint-up(md) {
-    width: calc(#{map-get($container-max-widths, md)} / 2 - #{$grid-gutter-width} / 2);
+    width: calc(
+      #{map-get($container-max-widths, md)} / 2 - #{$grid-gutter-width} / 2
+    );
   }
 
   @include media-breakpoint-up(lg) {
-    width: calc(#{map-get($container-max-widths, lg)} / 2 - #{$grid-gutter-width} / 2);
+    width: calc(
+      #{map-get($container-max-widths, lg)} / 2 - #{$grid-gutter-width} / 2
+    );
   }
 
   @include media-breakpoint-up(xl) {
-    width: calc(#{map-get($container-max-widths, xl)} / 2 - #{$grid-gutter-width} / 2);
+    width: calc(
+      #{map-get($container-max-widths, xl)} / 2 - #{$grid-gutter-width} / 2
+    );
   }
 }
 
@@ -53,7 +71,7 @@ ContentBoxGroup__title {
   font-size: 1.8125rem;
   line-height: 1.2;
   margin-bottom: 1rem;
-  font-family: "Alegreya Sans";
+  font-family: 'Alegreya Sans';
   text-transform: uppercase;
 }
 
@@ -91,7 +109,6 @@ ContentBoxGroup__title {
     flex-grow: 1;
     justify-content: flex-end;
   }
-
 }
 
 .ContentBox__overlay-link-arrow {

--- a/src/components/contentful/contentfulContentBoxGroup/contentfulServiceBox.js
+++ b/src/components/contentful/contentfulContentBoxGroup/contentfulServiceBox.js
@@ -25,7 +25,7 @@ const ContentfulServiceBox = ({
       {serviceIcon && (
         <>
           <div className="ServiceBox__service-icon" aria-hidden={true}>
-            <img src={serviceIcon.file.url} />
+            <img src={serviceIcon.file.url} alt="" />
           </div>{' '}
         </>
       )}

--- a/src/components/contentful/contentfulDonationForm/contentfulDonationForm.js
+++ b/src/components/contentful/contentfulDonationForm/contentfulDonationForm.js
@@ -1,16 +1,12 @@
-import { Link } from 'gatsby';
-// import PropTypes from 'prop-types';
 import React from 'react';
 import { useStripe } from '@stripe/react-stripe-js';
 import { loadStripe } from '@stripe/stripe-js';
-
-import Background from '../../background/background';
 
 import './contentfulDonationForm.scss';
 
 // Make sure to call `loadStripe` outside of a component’s render to avoid
 // recreating the `Stripe` object on every render.
-const stripePromise = loadStripe(
+loadStripe(
   'pk_test_51HcTSZIlFmfjuTJdc1LqP1HwrXGmDrHnvgpn8z7IGeul9XwvLf7S48yUqtxEE9xInitQZnVO5O0Zp3oh5rIESkaK00P1xuk6se',
 );
 

--- a/src/components/contentful/contentfulOpenLetterForm/contentfulOpenLetterForm.js
+++ b/src/components/contentful/contentfulOpenLetterForm/contentfulOpenLetterForm.js
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import axios from 'axios';
-import TextareaAutosize from 'react-textarea-autosize';
 
 import ReadLetterForm from './readLetterForm';
 import WriteLetterForm from './writeLetterForm';
@@ -14,8 +13,8 @@ const axiosConfig = {
 
 const OpenLetterForm = ({ content }) => {
   const {
-    writeALetterButtonText,
-    readYourLetterButtonText,
+    /* writeALetterButtonText,
+    readYourLetterButtonText, */
     title,
     description,
     defaultLanguage,
@@ -23,7 +22,7 @@ const OpenLetterForm = ({ content }) => {
 
   const [expandOpenLetterStart, setExpandOpenLetterStart] = useState(false);
   const [expandOpenLetterRead, setExpandOpenLetterRead] = useState(false);
-  const [accessKey, setAccessKey] = useState('');
+  const [letterKey, setLetterKey] = useState('');
   const [accessPassword, setAccessPassword] = useState('');
   const [loadingError, setLoadingError] = useState('');
 
@@ -38,7 +37,7 @@ const OpenLetterForm = ({ content }) => {
       )
       .then(function (response) {
         // handle success
-        setAccessKey(response.data.data.accessKey);
+        setLetterKey(response.data.data.accessKey);
         setAccessPassword(response.data.data.accessPassword);
         setExpandOpenLetterStart(true);
       })
@@ -75,9 +74,9 @@ const OpenLetterForm = ({ content }) => {
           </>
         )}
 
-        {expandOpenLetterStart && accessKey && accessPassword && (
+        {expandOpenLetterStart && letterKey && accessPassword && (
           <WriteLetterForm
-            accessKey={accessKey}
+            letterKey={letterKey}
             accessPassword={accessPassword}
             language={defaultLanguage}
           />

--- a/src/components/contentful/contentfulOpenLetterForm/contentfulOpenLetterForm.js
+++ b/src/components/contentful/contentfulOpenLetterForm/contentfulOpenLetterForm.js
@@ -48,6 +48,7 @@ const OpenLetterForm = ({ content }) => {
 
   return (
     <section className="OpenLetterForm full-width-section">
+      {loadingError && <div>{loadingError}</div>}
       <div className="layout-container">
         <h1>{title}</h1>
         {!expandOpenLetterStart && !expandOpenLetterRead && (

--- a/src/components/contentful/contentfulOpenLetterForm/readLetterForm.js
+++ b/src/components/contentful/contentfulOpenLetterForm/readLetterForm.js
@@ -107,7 +107,7 @@ const AccessKeyAndPasswordForm = ({ setOpenLetterContent, language }) => {
         setIsLoading(false);
       }
     },
-    [letterKey, accessPassword],
+    [letterKey, accessPassword, setOpenLetterContent, t],
   );
 
   return (

--- a/src/components/contentful/contentfulOpenLetterForm/readLetterForm.js
+++ b/src/components/contentful/contentfulOpenLetterForm/readLetterForm.js
@@ -9,7 +9,7 @@ const axiosConfig = {
   headers: { 'Content-Type': 'application/json' },
 };
 
-const ReadLetterForm = ({ content, language }) => {
+const ReadLetterForm = ({ /* content, */ language }) => {
   const [openLetterContent, setOpenLetterContent] = useState(null);
 
   return (
@@ -71,7 +71,7 @@ const LetterContent = ({ openLetterContent, language }) => {
 
 const AccessKeyAndPasswordForm = ({ setOpenLetterContent, language }) => {
   const [isLoading, setIsLoading] = useState(false);
-  const [accessKey, setAccessKey] = useState('');
+  const [letterKey, setLetterKey] = useState('');
   const [accessPassword, setAccessPassword] = useState('');
   const [errorMessage, setErrorMessage] = useState(null);
   const t = translations[language] ?? translations.fi;
@@ -80,8 +80,8 @@ const AccessKeyAndPasswordForm = ({ setOpenLetterContent, language }) => {
     async (e) => {
       e.preventDefault();
       setErrorMessage(null);
-      if (!accessKey.trim()) {
-        setErrorMessage(t['openLetterForm.error.accessKeyMissing']);
+      if (!letterKey.trim()) {
+        setErrorMessage(t['openLetterForm.error.letterKeyMissing']);
         return;
       }
       if (!accessPassword) {
@@ -93,7 +93,7 @@ const AccessKeyAndPasswordForm = ({ setOpenLetterContent, language }) => {
       try {
         const response = await axios.post(
           `${SERVICE_API_URL}/online-letter/read`,
-          { accessKey: accessKey, accessPassword: accessPassword },
+          { accessKey: letterKey, accessPassword: accessPassword },
           axiosConfig,
         );
         setOpenLetterContent(response.data.data);
@@ -107,7 +107,7 @@ const AccessKeyAndPasswordForm = ({ setOpenLetterContent, language }) => {
         setIsLoading(false);
       }
     },
-    [accessKey, accessPassword],
+    [letterKey, accessPassword],
   );
 
   return (
@@ -127,11 +127,12 @@ const AccessKeyAndPasswordForm = ({ setOpenLetterContent, language }) => {
 
       <div className="OpenLetterForm__credentials">
         <div className="OpenLetterForm__credential">
-          <label htmlFor="accessKey">{t['openLetterForm.accessKey']}</label>
+          <label htmlFor="letterKey">{t['openLetterForm.letterKey']}</label>
           <input
-            onChange={(e) => setAccessKey(e.target.value)}
+            onChange={(e) => setLetterKey(e.target.value)}
             type="text"
-            name="accessKey"
+            id="letterKey"
+            name="letterKey"
             required
           />
         </div>
@@ -142,6 +143,7 @@ const AccessKeyAndPasswordForm = ({ setOpenLetterContent, language }) => {
           <input
             onChange={(e) => setAccessPassword(e.target.value)}
             type="password"
+            id="accessPassword"
             name="accessPassword"
             required
           />

--- a/src/components/contentful/contentfulOpenLetterForm/translations.js
+++ b/src/components/contentful/contentfulOpenLetterForm/translations.js
@@ -7,7 +7,7 @@ export const translations = {
     'openLetterForm.subject': 'Subject',
     'openLetterForm.content': 'Content',
     'openLetterForm.ourResponse': 'Our response',
-    'openLetterForm.accessKey': 'Access key',
+    'openLetterForm.letterKey': 'Access key',
     'openLetterForm.accessPassword': 'Access password',
     'openLetterForm.letterSent': 'Your message was sent to us!',
     'openLetterForm.recordCredentialsReminder':
@@ -29,7 +29,7 @@ export const translations = {
     'openLetterForm.error.contentMissing': 'Your letter content is missing',
     'openLetterForm.error.failedToFetchLetter': `There was an error while fetching your message. Please report this issue through <a href="${finnishFeedbackFormUrl}">our feedback form</a>.`,
     'openLetterForm.error.sendingFailed': `There was an issue with sending your leter. Please refresh this page and try again, or contact let us know about the issue through <a href="${finnishFeedbackFormUrl}">the feedback form</a>.`,
-    'openLetterForm.error.accessKeyMissing': 'Please provide the access key',
+    'openLetterForm.error.letterKeyMissing': 'Please provide the access key',
     'openLetterForm.error.accessPasswordMissing':
       'Please provide the access password',
     'openLetterForm.error.wrongCredentials':
@@ -40,7 +40,7 @@ export const translations = {
     'openLetterForm.subject': 'Viestin otsikko',
     'openLetterForm.content': 'Viesti',
     'openLetterForm.ourResponse': 'Vastauksemme',
-    'openLetterForm.accessKey': 'Käyttäjätunnuksesi',
+    'openLetterForm.letterKey': 'Käyttäjätunnuksesi',
     'openLetterForm.accessPassword': 'Salasanasi',
     // TODO: translate me!
     'openLetterForm.letterSent': 'Your message was sent to us!',
@@ -53,8 +53,7 @@ export const translations = {
     'openLetterForm.button.writeANewLetter': 'Kirjoita uusi kirje',
     'openLetterForm.button.readResponse': 'Nouda vastaus',
     'openLetterForm.button.cancel': 'Peruuta',
-    // TODO: translate me!
-    'openLetterForm.button.send': 'Send',
+    'openLetterForm.button.send': 'Lähetä',
     'openLetterForm.button.closeLetter': 'Sulje kirje',
     // TODO: translate me!
     'openLetterForm.button.credentialsRecorded':
@@ -68,7 +67,7 @@ export const translations = {
     'openLetterForm.error.failedToFetchLetter': `Vastauksen noutamisessa tapahtui virhe. Yritä uudelleen (mieluiten toisella selaimella) tai ota yhteyttä <a href="${finnishFeedbackFormUrl}">palautelomakkeella</a>.`,
     'openLetterForm.error.sendingFailed': `Vastauksen lähettämisessä tapahtui virhe. Kopioi kirje talteen itsellesi esimerkiksi tekstinkäsittelyohjelmaan tai muistioon. Tämän jälkeen päivitä sivu tai avaa uusi selain, ja yritä lähettää uusi viesti. Jos tarvitset apua, voit olla yhteydessä <a href="${finnishFeedbackFormUrl}">palautelomakkeella</a>`,
     // TODO: translate me!
-    'openLetterForm.error.accessKeyMissing': 'Please provide the access key',
+    'openLetterForm.error.letterKeyMissing': 'Please provide the access key',
     // TODO: translate me!
     'openLetterForm.error.accessPasswordMissing':
       'Please provide the access password',
@@ -80,7 +79,7 @@ export const translations = {
     'openLetterForm.subject': ' Rubrik',
     'openLetterForm.content': 'Meddelande',
     'openLetterForm.ourResponse': 'Vårt svar',
-    'openLetterForm.accessKey': 'Användarnamn',
+    'openLetterForm.letterKey': 'Användarnamn',
     'openLetterForm.accessPassword': 'Lösenord',
     // TODO: translate me!
     'openLetterForm.letterSent': 'Your message was sent to us!',
@@ -108,7 +107,7 @@ export const translations = {
     'openLetterForm.error.failedToFetchLetter': `Ett fel uppstod och ditt svar gick inte att hämta. Vänligen försök på nytt (gärna i en annan webbläsare) eller kontakta oss för hjälp via vårt <a href="${finnishFeedbackFormUrl}">responsformulär</a>.`,
     'openLetterForm.error.sendingFailed': `Ett fel uppstod och det gick inte att skicka ditt brev. Kopiera brevet och spara det tillfälligt på din dator, till exempel i ett textediteringsprogram. Efter att du sparat brevet kan du pröva att uppdatera sidan eller försöka på nytt i en annan webbläsare. Om du behöver hjälp kan du vara i kontakt med oss via vårt  <a href="${finnishFeedbackFormUrl}">responsformulär</a>`,
     // TODO: translate me!
-    'openLetterForm.error.accessKeyMissing': 'Please provide the access key',
+    'openLetterForm.error.letterKeyMissing': 'Please provide the access key',
     // TODO: translate me!
     'openLetterForm.error.accessPasswordMissing':
       'Please provide the access password',

--- a/src/components/contentful/contentfulOpenLetterForm/writeLetterForm.js
+++ b/src/components/contentful/contentfulOpenLetterForm/writeLetterForm.js
@@ -9,7 +9,7 @@ import { translations } from './translations';
 import '../../../scss/grid.scss';
 import './contentfulOpenLetterForm.scss';
 
-const WriteLetterForm = ({ accessKey, accessPassword, language }) => {
+const WriteLetterForm = ({ letterKey, accessPassword, language }) => {
   const [isLoading, setIsLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState(null);
   const [isLetterSent, setIsLetterSent] = useState(false);
@@ -31,7 +31,7 @@ const WriteLetterForm = ({ accessKey, accessPassword, language }) => {
       }
       axios
         .post(`${SERVICE_API_URL}/online-letter/send`, {
-          accessKey,
+          letterKey,
           accessPassword,
           title: openLetterTitle,
           content: openLetterContent,
@@ -46,7 +46,7 @@ const WriteLetterForm = ({ accessKey, accessPassword, language }) => {
           setIsLoading(false);
         });
     },
-    [accessKey, accessPassword, openLetterTitle, openLetterContent, t],
+    [letterKey, accessPassword, openLetterTitle, openLetterContent, t],
   );
 
   const updateLetterTitle = (e) => setOpenLetterTitle(e.target.value);
@@ -74,12 +74,13 @@ const WriteLetterForm = ({ accessKey, accessPassword, language }) => {
 
         <div className="OpenLetterForm__credentials">
           <div className="OpenLetterForm__credential">
-            <label htmlFor="accessKey">{t['openLetterForm.accessKey']}</label>
+            <label htmlFor="letterKey">{t['openLetterForm.letterKey']}</label>
             <input
               className="access-credential-value"
               type="text"
-              name="accessKey"
-              value={accessKey}
+              id="letterKey"
+              name="letterKey"
+              value={letterKey}
               disabled
             />
           </div>
@@ -114,12 +115,12 @@ const WriteLetterForm = ({ accessKey, accessPassword, language }) => {
       {isLoading && <FullPageLoader />}
       <div className="OpenLetterForm__credentials">
         <div className="OpenLetterForm__credential">
-          <label htmlFor="accessKey">{t['openLetterForm.accessKey']}</label>
+          <label htmlFor="letterKey">{t['openLetterForm.letterKey']}</label>
           <input
             className="access-credential-value"
             type="text"
-            name="accessKey"
-            value={accessKey}
+            name="letterKey"
+            value={letterKey}
             disabled
           />
         </div>

--- a/src/components/globals.scss
+++ b/src/components/globals.scss
@@ -30,7 +30,8 @@ $contentful-colors: (
 
 .ContentfulBackground--none.ContentfulTextColor--dark,
 .ContentfulBackground--wavy.ContentfulTextColor--dark,
-[style*='background-color: rgb(125, 142, 221);'] {
+[style*='background-color: rgb(125, 142, 221);'],
+[style*='background-color: rgb(237, 238, 239);'] {
   & *:focus {
     outline: 0.25rem solid #363842;
   }

--- a/src/components/globals.scss
+++ b/src/components/globals.scss
@@ -1,16 +1,53 @@
 $contentful-colors: (
-  "white": #edeeef,
-  "pink": #ffc4c8,
-  "violet-blue": #7d8edd,
-  "gray": #b6b8c1,
-  "dark-gray": "#363842",
+  'white': #edeeef,
+  'pink': #ffc4c8,
+  'violet-blue': #7d8edd,
+  'gray': #b6b8c1,
+  'dark-gray': #363842,
 );
 
 @each $name, $value in $contentful-colors {
   .ContentfulBackgroundColor--#{$name} {
     background-color: $value;
+
+    @if not $value == 'dark-gray' {
+      & *:focus {
+        outline: 0.25rem solid #363842;
+      }
+
+      & .ContentBox__wrapper,
+      .ServiceBox__wrapper {
+        a:focus {
+          outline: 0.25rem solid #363842 !important;
+        }
+        &:focus-within {
+          outline: 0.25rem solid #363842 !important;
+        }
+      }
+    }
+  }
+}
+
+.ContentfulBackground--none.ContentfulTextColor--dark,
+.ContentfulBackground--wavy.ContentfulTextColor--dark {
+  & *:focus {
+    outline: 0.25rem solid #363842;
   }
 
+  & .ContentBox__wrapper,
+  .ServiceBox__wrapper {
+    a:focus {
+      outline: 0.25rem solid #363842 !important;
+    }
+    &:focus-within {
+      outline: 0.25rem solid #363842 !important;
+    }
+  }
+}
+
+*:focus {
+  outline: 0.25rem solid #fec3c8;
+  outline-offset: 0.15rem;
 }
 
 $text-color-dark: #2e303a;
@@ -18,14 +55,24 @@ $text-color-light: #ffffff;
 
 .ContentfulTextColor--dark {
   color: $text-color-dark;
-  h1, h2, h3, h4, h5, a {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  a {
     color: $text-color-dark;
   }
 }
 
 .ContentfulTextColor--light {
   color: $text-color-light;
-  h1, h2, h3, h4, h5, a {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  a {
     color: $text-color-light;
   }
 }
@@ -39,22 +86,22 @@ $text-color-light: #ffffff;
   justify-content: center;
   padding: 0 2rem;
   color: #363842;
-  background: #71BEB9;
+  background: #71beb9;
   border: none;
   box-shadow: none;
   cursor: pointer;
   margin: 1rem 0.5rem;
 }
 
-input[type="text"],
-input[type="text"]:focus,
-input[type="text"]:focus-visible,
-input[type="password"],
-input[type="password"]:focus,
-input[type="password"]:focus-visible,
-input[type="email"],
-input[type="email"]:focus,
-input[type="email"]:focus-visible,
+input[type='text'],
+input[type='text']:focus,
+input[type='text']:focus-visible,
+input[type='password'],
+input[type='password']:focus,
+input[type='password']:focus-visible,
+input[type='email'],
+input[type='email']:focus,
+input[type='email']:focus-visible,
 textarea,
 textarea:focus,
 textarea:focus-visible {
@@ -62,7 +109,6 @@ textarea:focus-visible {
   background: #363842;
   border: none;
   color: #edeeef;
-  outline: none;
   box-shadow: none;
   padding: 0.5rem 1rem;
   font-size: 1.5rem;
@@ -78,7 +124,6 @@ textarea {
     border: 1px solid #edeeef;
   }
 }
-
 
 form {
   width: 100%;

--- a/src/components/globals.scss
+++ b/src/components/globals.scss
@@ -29,7 +29,8 @@ $contentful-colors: (
 }
 
 .ContentfulBackground--none.ContentfulTextColor--dark,
-.ContentfulBackground--wavy.ContentfulTextColor--dark {
+.ContentfulBackground--wavy.ContentfulTextColor--dark,
+[style*='background-color: rgb(125, 142, 221);'] {
   & *:focus {
     outline: 0.25rem solid #363842;
   }


### PR DESCRIPTION
This PR contains improvements to accessibility, mainly fixes to things I found during auditing the site. Also, I've done some removing of non used variables, so that the linter wouldn't complain about those. This resolves #37 

Improvements in more detail:
- Add focus indicator, which passes the color contrast requirements
- Attach labels to inputs programmatically (the id on the input was missing)

Also, I renamed the `accessKey`-attribute, because there is an [HTML-attribute called accesskey](https://developer.cdn.mozilla.net/en-US/docs/Web/HTML/Global_attributes/accesskey),  so it's sort of reserved name.

Some screenshots of the focus indicators:

![Four grey boxes with contact information on blue background. One of them has a light pink focus indicator around it.](https://user-images.githubusercontent.com/28345294/114339173-41045980-9b5d-11eb-90e8-981a0330835c.png)
![Dark grey text on white background, topmost there is a link to Turvaverkko-page, which has a dark grey focus indicator around it.](https://user-images.githubusercontent.com/28345294/114339175-419cf000-9b5d-11eb-8606-a7385d9ba512.png)
