### PR TITLE
Fix/Empty headings appearing in DOM

### DIFF
--- a/src/components/contentful/contentfulParagraph/contentfulParagraph.js
+++ b/src/components/contentful/contentfulParagraph/contentfulParagraph.js
@@ -44,11 +44,13 @@ const ContentfulParagraph = ({ content }) => {
     >
       <div className="full-width-section">
         <div className={`Paragraph ${textColor || 'light'} layout-container`}>
-          {!!content.paragraphTitle && content.paragraphTitle !== '' && (
-            <div className="row">
-              <h2 className="Paragraph__title">{content.paragraphTitle}</h2>
-            </div>
-          )}
+          {!!content.paragraphTitle &&
+            content.paragraphTitle !== '' &&
+            content.paragraphTitle !== ' ' && (
+              <div className="row">
+                <h2 className="Paragraph__title">{content.paragraphTitle}</h2>
+              </div>
+            )}
           <div className="row">
             {paragraphImagePosition === 'left' &&
               content.sideImage &&


### PR DESCRIPTION
I added one more check for situations where there is a space-character inserted for some reason (filling a "required" condition?) for the title, so that the h2 wouldn't appear on DOM as an empty heading.

This might affect the looks of the website (as the empty heading has added some extra padding) so let's not merge this just yet