### PR TITLE
Fix sansita font issue on Safari

### DIFF
--- a/src/components/contentful/contentfulParagraph/contentfulParagraph.scss
+++ b/src/components/contentful/contentfulParagraph/contentfulParagraph.scss
@@ -1,4 +1,5 @@
 @import '../../../scss/grid.scss';
+@import '../../mixins.scss';
 
 .Paragraph {
   padding: 1.5rem;
@@ -14,10 +15,8 @@
   }
 
   &__title {
+    @include sansita-font;
     font-size: 2.8rem;
-    font-family: 'Sansita';
-    font-style: normal;
-    font-weight: normal;
     letter-spacing: 0.09em;
     text-align: center;
     width: 100%;

--- a/src/components/header/header.scss
+++ b/src/components/header/header.scss
@@ -111,8 +111,6 @@ header {
   h1 {
     text-align: center;
     margin-top: 32px;
-    font-style: normal;
-    font-weight: normal;
     font-size: 37px;
     line-height: 110%;
     text-align: center;

--- a/src/components/layout.scss
+++ b/src/components/layout.scss
@@ -632,9 +632,7 @@ body {
 }
 
 h1 {
-  font-family: 'Sansita';
-  font-style: normal;
-  font-weight: 800;
+  @include sansita-font;
   letter-spacing: 0.09em;
 }
 
@@ -705,6 +703,3 @@ a:visited {
   flex-wrap: wrap;
   align-items: flex-start;
 }
-
-
-

--- a/src/components/mixins.scss
+++ b/src/components/mixins.scss
@@ -11,3 +11,9 @@
     width: map-get($container-max-widths, xl);
   }
 }
+
+@mixin sansita-font {
+  font-family: 'Sansita';
+  font-weight: 800;
+  font-style: italic;
+}


### PR DESCRIPTION
Due to Safari being stricter about font loading, the browser requires both `font-style` and `font-weight` to be defined exactly for the usage, whereas other browsers would fallback on the available styles.
And I only included one font-style for Sansita to avoid loading the full font suit without using most of them, so this PR ensures the correct sansita font style and weight attributes are used so they're loaded properly on Safari.