### PR TITLE
Feature/add sitemap

### DIFF
--- a/src/components/footer/footer.js
+++ b/src/components/footer/footer.js
@@ -45,6 +45,11 @@ const Footer = () => (
         </Link>
       </li>
       <li>
+        <Link className="company-information" to="/sitemap">
+          Sivukartta
+        </Link>
+      </li>
+      <li>
         <Link className="company-information" to="/saavutettavuus">
           Saavutettavuusseloste
         </Link>

--- a/src/components/sitemap/sitemap-list.js
+++ b/src/components/sitemap/sitemap-list.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Link } from 'gatsby';
+
+const SitemapList = ({ pages, isTopLevel = false }) => {
+  return (
+    <ul>
+      {pages.map((page) => (
+        <li>
+          {isTopLevel && page.subPages ? (
+            <>{page.pageName}</>
+          ) : (
+            <>
+              {page.linkToExternalUrl ? (
+                <a href={page.linkToExternalUrl}>{page.pageName}</a>
+              ) : (
+                <Link to={`/${page.pageSlug}`}>{page.pageName}</Link>
+              )}
+            </>
+          )}
+          {page.subPages && <SitemapList pages={page.subPages} />}
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default SitemapList;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,0 +1,17 @@
+export const getSubPages = (pages) => {
+  if (pages === null) {
+    return null;
+  }
+
+  return pages.map((page) => {
+    return {
+      pageName:
+        !page.menuPage || (page.menuPageSubpages && page.pageContainerName)
+          ? page.pageContainerName
+          : page.menuPage.pageName,
+      pageSlug: page.menuPage ? page.menuPage.slug : '',
+      linkToExternalUrl: page.linkToExternalUrl,
+      subPages: getSubPages(page.menuPageSubpages),
+    };
+  });
+};

--- a/src/navigation-helpers.js
+++ b/src/navigation-helpers.js
@@ -1,6 +1,6 @@
 export const parseNavigationStructure = (pages) => {
   if (pages === null) {
-    return null;
+    return [];
   }
 
   return pages.map((page) => {

--- a/src/navigation-helpers.js
+++ b/src/navigation-helpers.js
@@ -1,4 +1,4 @@
-export const getSubPages = (pages) => {
+export const parseNavigationStructure = (pages) => {
   if (pages === null) {
     return null;
   }
@@ -11,7 +11,7 @@ export const getSubPages = (pages) => {
           : page.menuPage.pageName,
       pageSlug: page.menuPage ? page.menuPage.slug : '',
       linkToExternalUrl: page.linkToExternalUrl,
-      subPages: getSubPages(page.menuPageSubpages),
+      subPages: parseNavigationStructure(page.menuPageSubpages),
     };
   });
 };

--- a/src/pages/sitemap.js
+++ b/src/pages/sitemap.js
@@ -11,8 +11,12 @@ const SitemapPage = ({ data }) => {
     <Layout>
       <SEO title="Sivukartta" lang="fi" />
       <section className="full-width-content">
-        <h2>Sivukartta</h2>
-        <SitemapList pages={parsedNavData} isTopLevel={true} />
+        <div className="Paragraph layout-container">
+          <h2>
+            <strong>Sivukartta</strong>
+          </h2>
+          <SitemapList pages={parsedNavData} isTopLevel={true} />
+        </div>
       </section>
     </Layout>
   );

--- a/src/pages/sitemap.js
+++ b/src/pages/sitemap.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import { graphql } from 'gatsby';
+import Layout from '../components/layout';
+import SEO from '../components/seo';
+import { getSubPages } from '../helpers';
+import SitemapList from '../components/sitemap/sitemap-list';
+
+const SitemapPage = ({ data }) => {
+  const parsedNavData = getSubPages(data.contentfulMainMenu.topLevelPages);
+  return (
+    <Layout>
+      <SEO title="Sivukartta" lang="fi" />
+      <section className="full-width-content">
+        <h2>Sivukartta</h2>
+        <SitemapList pages={parsedNavData} isTopLevel={true} />
+      </section>
+    </Layout>
+  );
+};
+
+export default SitemapPage;
+
+export const pageQuery = graphql`
+  query MenuPageQuery {
+    contentfulMainMenu(slug: { eq: "header-menu" }) {
+      id
+      slug
+      topLevelPages {
+        id
+        linkToExternalUrl
+        menuPage {
+          pageName
+          slug
+        }
+        pageContainerName
+        menuPageSubpages {
+          id
+          linkToExternalUrl
+          menuPage {
+            pageName
+            slug
+            id
+          }
+          pageContainerName
+          menuPageSubpages {
+            linkToExternalUrl
+            menuPageSubpages {
+              linkToExternalUrl
+              menuPage {
+                pageName
+                slug
+              }
+              id
+            }
+            id
+            menuPage {
+              pageName
+              slug
+              id
+            }
+          }
+        }
+      }
+    }
+  }
+`;

--- a/src/pages/sitemap.js
+++ b/src/pages/sitemap.js
@@ -2,11 +2,13 @@ import React from 'react';
 import { graphql } from 'gatsby';
 import Layout from '../components/layout';
 import SEO from '../components/seo';
-import { getSubPages } from '../helpers';
+import { parseNavigationStructure } from '../navigation-helpers';
 import SitemapList from '../components/sitemap/sitemap-list';
 
 const SitemapPage = ({ data }) => {
-  const parsedNavData = getSubPages(data.contentfulMainMenu.topLevelPages);
+  const parsedNavData = parseNavigationStructure(
+    data.contentfulMainMenu.topLevelPages,
+  );
   return (
     <Layout>
       <SEO title="Sivukartta" lang="fi" />

--- a/src/pages/sitemap.js
+++ b/src/pages/sitemap.js
@@ -29,10 +29,7 @@ export default SitemapPage;
 export const pageQuery = graphql`
   query MenuPageQuery {
     contentfulMainMenu(slug: { eq: "header-menu" }) {
-      id
-      slug
       topLevelPages {
-        id
         linkToExternalUrl
         menuPage {
           pageName
@@ -40,12 +37,10 @@ export const pageQuery = graphql`
         }
         pageContainerName
         menuPageSubpages {
-          id
           linkToExternalUrl
           menuPage {
             pageName
             slug
-            id
           }
           pageContainerName
           menuPageSubpages {
@@ -56,13 +51,10 @@ export const pageQuery = graphql`
                 pageName
                 slug
               }
-              id
             }
-            id
             menuPage {
               pageName
               slug
-              id
             }
           }
         }


### PR DESCRIPTION
This PR resolves #59 

It also adds sitemap, which can be found from http://localhost:8000/sitemap when the project is running locally. 

Here's a screenshot:

![Sitemap on Naisten Linja's website](https://user-images.githubusercontent.com/28345294/132116540-c6641ced-c467-4d71-bbc4-b1108675c983.png)

I admit, it could look better, but I'd say let's tweak the styles later.

Also, a thought: Maybe we could refactor the menu's code to be a bit cleaner with the `parseNavigationStructureHelper` 🤔 