### PR TITLE
Accessibility/Add role to cookie banner's wrapper

### DIFF
--- a/src/components/cookieBanner/cookieBanner.js
+++ b/src/components/cookieBanner/cookieBanner.js
@@ -9,6 +9,7 @@ const translations = {
       'Tämä sivusto käyttää evästeitä toimiakseen. Jatkamalla selaamista hyväksyt evästeiden käytön.',
     consent: 'Hyväksyn ',
     privacyPolicy: 'Yksityisyyskäytäntö',
+    cookieBanner: 'Sivuston evästeet',
   },
 };
 
@@ -31,7 +32,7 @@ export const CookieBanner = () => {
 
   const t = translations.fi;
   return (
-    <div className="cookie-banner">
+    <div role="region" className="cookie-banner" aria-label={t.cookieBanner}>
       <div className="layout-container">
         <p>
           {t.message}{' '}


### PR DESCRIPTION
I ran some accessibility tests, and noticed, that the cookie banner was outside any landmarks, so I added the `role="region"` to it, as it seems to be the most appropriate role for this kind of elements.

In short, this improves navigability of the site for screen reader users. [More info about the all content being contained in landmarks or regions in Deque's site. ](https://dequeuniversity.com/rules/axe/4.3/region?application=AxeChrome)